### PR TITLE
FIX(container): add menu containers public re-export

### DIFF
--- a/egui/src/containers.rs
+++ b/egui/src/containers.rs
@@ -8,6 +8,6 @@ pub(crate) mod scroll_area;
 pub(crate) mod window;
 
 pub use {
-    area::Area, collapsing_header::CollapsingHeader, frame::Frame, popup::*, resize::Resize,
-    scroll_area::ScrollArea, window::Window,
+    area::Area, collapsing_header::CollapsingHeader, frame::Frame, menu::*, popup::*,
+    resize::Resize, scroll_area::ScrollArea, window::Window,
 };


### PR DESCRIPTION
Really like the concept of this library and was eager to try some stuff out.

Was really happy to find the menu containers in the documentation, but the compiler complained they were private in the module.

I'm not totally sure if my fix is the correct/planned way for adding the menu containers, but it seems to work :D

(P.S.: Sorry for the push spam. Apparently I should really start looking at the details of my work before pushing, because I'm too stupid to get them right the first time...)