### PR TITLE
Add `collapsible` to Window

### DIFF
--- a/egui/src/containers/window.rs
+++ b/egui/src/containers/window.rs
@@ -12,6 +12,7 @@ pub struct Window<'open> {
     pub frame: Option<Frame>,
     pub resize: Resize,
     pub scroll: Option<ScrollArea>,
+    pub collapsible: bool,
 }
 
 impl<'open> Window<'open> {
@@ -36,6 +37,7 @@ impl<'open> Window<'open> {
                     .always_show_scroll(false)
                     .max_height(f32::INFINITY),
             ), // As large as we can be
+            collapsible: true,
         }
     }
 
@@ -103,6 +105,12 @@ impl<'open> Window<'open> {
         self
     }
 
+    /// Can the window be collapsed by clicking on its title?
+    pub fn collapsible(mut self, collapsible: bool) -> Self {
+        self.collapsible = collapsible;
+        self
+    }
+
     /// Not resizable, just takes the size of its contents.
     pub fn auto_sized(mut self) -> Self {
         self.resize = self.resize.auto_sized();
@@ -139,6 +147,7 @@ impl<'open> Window<'open> {
             frame,
             resize,
             scroll,
+            collapsible,
         } = self;
 
         if matches!(open, Some(false)) {
@@ -213,6 +222,7 @@ impl<'open> Window<'open> {
                 show_close_button,
                 collapsing_id,
                 &mut collapsing,
+                collapsible,
             );
 
             let content_rect = collapsing
@@ -239,6 +249,7 @@ impl<'open> Window<'open> {
                 content_rect,
                 open,
                 &mut collapsing,
+                collapsible,
             );
 
             area_content_ui
@@ -534,6 +545,7 @@ fn show_title_bar(
     show_close_button: bool,
     collapsing_id: Id,
     collapsing: &mut collapsing_header::State,
+    collapsible: bool,
 ) -> TitleBar {
     let title_bar_and_rect = ui.inner_layout(Layout::horizontal(Align::Center), |ui| {
         ui.set_desired_height(title_label.font_height(ui.fonts()));
@@ -541,7 +553,7 @@ fn show_title_bar(
         let item_spacing = ui.style().item_spacing;
         let button_size = ui.style().start_icon_width;
 
-        {
+        if collapsible {
             // TODO: make clickable radius larger
             ui.allocate_space(vec2(0.0, 0.0)); // HACK: will add left spacing
 
@@ -592,6 +604,7 @@ impl TitleBar {
         content_rect: Option<Rect>,
         open: Option<&mut bool>,
         collapsing: &mut collapsing_header::State,
+        collapsible: bool,
     ) {
         if let Some(content_rect) = content_rect {
             // Now we know how large we got to be:
@@ -624,6 +637,7 @@ impl TitleBar {
         if ui
             .interact(self.rect, title_bar_id, Sense::click())
             .double_clicked
+            && collapsible
         {
             collapsing.toggle(ui);
         }


### PR DESCRIPTION
This lets the user decide whether the Window can be collapsed or not.
The default is `true` (window is collapsible), but calling
`window.collapsible(false)` will hide the collapsing triangle icon and
prevent the window from being collapsed by clicking on the title.